### PR TITLE
Installation step: Fixed the repos file name

### DIFF
--- a/tech_setup/workshops/0.Setup_Environment.md
+++ b/tech_setup/workshops/0.Setup_Environment.md
@@ -68,7 +68,7 @@ Now we have setup the folder structure and we are ready to download the workshop
 ```bash
 git clone https://github.com/ipa-cmh/ros2_manipulation_workshop.git src
 cd src
-vcs import --input manipulation_workshop.repos
+vcs import --input manipulation_training.repos
 ```
 
 **Now your workspace is setup and we are ready to open the development environment.**


### PR DESCRIPTION
Change the file name from `manipulation_workshop.repos` to  `manipulation_training.repos` as in [here](https://github.com/ipa-vsp/ros2_manipulation_workshop.git).